### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-// Types for minecraft json models (see https://minecraft.fandom.com/wiki/Model)
+// Types for minecraft json models (see https://minecraft.wiki/w/Model)
 
 import { Loader, FileLoader } from 'three'
 import { MinecraftModel, validateMinecraftModelJson, MinecraftModelJson } from '@oran9e/minecraft-model'


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.